### PR TITLE
Fix player death on load and control sync when changing dimensions

### DIFF
--- a/neoforge/src/main/java/com/possible_triangle/flightlib/neoforge/NeoForgeEntrypoint.java
+++ b/neoforge/src/main/java/com/possible_triangle/flightlib/neoforge/NeoForgeEntrypoint.java
@@ -36,6 +36,23 @@ public class NeoForgeEntrypoint {
         ForgeDataAttachment.register(modBus);
 
         NeoForge.EVENT_BUS.addListener((PlayerTickEvent.Pre event) -> JetpackLogic.INSTANCE.onTick(event.getEntity()));
+
+        NeoForge.EVENT_BUS.addListener((PlayerEvent.PlayerLoggedInEvent event) -> {
+            if (event.getEntity() instanceof ServerPlayer player) {
+                ControlManager.INSTANCE.load(player);
+            }
+        });
+        NeoForge.EVENT_BUS.addListener((PlayerEvent.PlayerChangedDimensionEvent event) -> {
+            if (event.getEntity() instanceof ServerPlayer player) {
+                ControlManager.INSTANCE.load(player);
+            }
+        });
+        NeoForge.EVENT_BUS.addListener((PlayerEvent.PlayerRespawnEvent event) -> {
+            if (event.getEntity() instanceof ServerPlayer player) {
+                ControlManager.INSTANCE.load(player);
+            }
+        });
+
     }
 
     private void clientInit(IEventBus modBus) {
@@ -47,11 +64,6 @@ public class NeoForgeEntrypoint {
             if (event.getEntity() instanceof LocalPlayer player) ControlSender.INSTANCE.onTick(player);
         });
 
-        NeoForge.EVENT_BUS.addListener((PlayerEvent.PlayerLoggedInEvent event) -> {
-            if (event.getEntity() instanceof ServerPlayer player) {
-                ControlManager.INSTANCE.load(player);
-            }
-        });
     }
 
 }


### PR DESCRIPTION
This change fixes two problems:
• Prevents players from dying during landing.
• Restores proper synchronization when a player changes dimension.

Related issues:

- https://github.com/PssbleTrngle/CreateJetpack/issues/190
- https://github.com/PssbleTrngle/CreateJetpack/issues/180
- https://github.com/PssbleTrngle/CreateJetpack/issues/170
- https://github.com/PssbleTrngle/CreateJetpack/issues/168